### PR TITLE
Fixed ContentType for blob files

### DIFF
--- a/WebApp-Storage-DotNet/Controllers/HomeController.cs
+++ b/WebApp-Storage-DotNet/Controllers/HomeController.cs
@@ -112,7 +112,8 @@ namespace WebApp_Storage_DotNet.Controllers
                     for (int i = 0; i < fileCount; i++)
                     {
                         CloudBlockBlob blob = blobContainer.GetBlockBlobReference(GetRandomBlobName(files[i].FileName));
-                        await blob.UploadFromFileAsync(files[i].FileName, FileMode.Open);
+                        blob.Properties.ContentType = files[i].ContentType;
+                        await blob.UploadFromStreamAsync(files[i].InputStream);    
                     }
                 }
                 return RedirectToAction("Index");


### PR DESCRIPTION
added content type support for uploaded files and use InputStream for Azure Blob Stream.
Otherwise uploaded files will be stores as "application/octetstream" - that causes issues with modern browsers like Edge, Chrome, etc.
